### PR TITLE
Replace RustCrypto with AWS-LC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,7 @@ itertools = "0.10"
 log = "0.4"
 oauth2 = { version = "5.0.0", default-features = false }
 rand = "0.8.5"
-hmac = "0.12.1"
-rsa = "0.9.2"
-sha2 = { version = "0.10.6", features = ["oid"] } # Object ID needed for pkcs1v15 padding
-p256 = "0.13.2"
-p384 = "0.13.0"
+aws-lc-rs = { version = "1.14.1", features = ["ring-io"] }
 dyn-clone = "1.0.10"
 serde = "1.0"
 serde_json = "1.0"
@@ -68,7 +64,7 @@ serde_with = "3"
 serde-value = "0.7"
 url = { version = "2.4", features = ["serde"] }
 subtle = "2.4"
-ed25519-dalek = { version = "2.0.0", features = ["pem"] }
+rustls-pemfile = "2.2.0"
 
 [dev-dependencies]
 color-backtrace = { version = "0.5" }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -257,8 +257,7 @@ macro_rules! new_secret_type {
         #[cfg(any(test, feature = "timing-resistant-secret-traits"))]
         impl PartialEq for $name {
             fn eq(&self, other: &Self) -> bool {
-                <sha2::Sha256 as sha2::Digest>::digest(&self.0)
-                  == <sha2::Sha256 as sha2::Digest>::digest(&other.0)
+                aws_lc_rs::constant_time::verify_slices_are_equal(&self.0.as_ref(), &other.0.as_ref()).is_ok()
             }
         }
 


### PR DESCRIPTION
RustCrypto's RSA implementation is a lot slower than AWS-LC, something like 8x slower if https://jbp.io/graviola/ is to be believed. Also `rsa` still has an open RUSTSEC advisory.